### PR TITLE
Thx 50480: Updates to datastores-api yaml

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -410,7 +410,7 @@ definitions:
         description: The secondary key value of the record
       result:
         type: string
-        example: 204
+        example: "204"
         description: The result code of the insert operation.
       url:
         type: string

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -357,6 +357,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Definition'
+        minItems: 1
+        maxItems: 40
         example:
           - name: customerID
             type: TEXT


### PR DESCRIPTION
Just some minor updates to the Datastore API spec:

1. Added min/max number of items to the definition request obj
2. Updated the example for the data record insert response to be the correct type (int -> string)